### PR TITLE
Preserve sorting of references

### DIFF
--- a/Classes/SignalSlot/Repair.php
+++ b/Classes/SignalSlot/Repair.php
@@ -168,7 +168,9 @@ class Repair
         $rows = $this->getDatabaseConnection()->exec_SELECTgetRows(
             '*',
             'sys_file_reference',
-            implode(' AND ', $where)
+            implode(' AND ', $where),
+            '',
+            'sorting_foreign ASC'
         );
         if (empty($rows)) {
             $rows = array();


### PR DESCRIPTION
Order of sys_file_references got lost through this extension, now the sorting_foreign field is respected again.
Resolves issue #3 