### PR TITLE
[BUGFIX] Respect AllowLanguageSynchronization option on Translations

### DIFF
--- a/Classes/SignalSlot/Repair.php
+++ b/Classes/SignalSlot/Repair.php
@@ -135,7 +135,13 @@ class Repair
      */
     protected function isRecordConfiguredToUseDefaultLanguage(array $sysFileRecord, array $foreignRecord)
     {
+        $isNotTranslatable =
+            !isset($GLOBALS['TCA'][$sysFileRecord['tablenames']]['columns'][$sysFileRecord['fieldname']]['config']['behaviour']['allowLanguageSynchronization'])
+            || (isset($GLOBALS['TCA'][$sysFileRecord['tablenames']]['columns'][$sysFileRecord['fieldname']]['config']['behaviour']['allowLanguageSynchronization'])
+                && $GLOBALS['TCA'][$sysFileRecord['tablenames']]['columns'][$sysFileRecord['fieldname']]['config']['behaviour']['allowLanguageSynchronization']);
+
         return VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= 8006000
+            && $isNotTranslatable
             && array_key_exists('l10n_state', $foreignRecord)
             && $this->configuredToUseDefaultLanguage($foreignRecord['l10n_state'], $sysFileRecord['fieldname']);
     }


### PR DESCRIPTION
Respect TYPO3 V8.6 Behaviour -> AllowLanguageSynchronization when applying translations.
https://docs.typo3.org/typo3cms/TCAReference/8.7/ColumnsConfig/Type/Inline.html#behaviour

Fix Issue: https://github.com/froemken/repair_translation/issues/14